### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/igormcsouza/missionary-lunch-calendar/security/code-scanning/1](https://github.com/igormcsouza/missionary-lunch-calendar/security/code-scanning/1)

In general, the problem is fixed by explicitly specifying `permissions` for the `GITHUB_TOKEN` in the workflow, restricting it to the least privilege required. For a simple lint job that only reads source code and does not modify the repository or interact with PRs/issues, `contents: read` is sufficient and recommended.

The best fix here is to add a `permissions` block at the workflow root level (top-level, alongside `name` and `on`) so it applies to all jobs. We will set:
```yaml
permissions:
  contents: read
```
No existing functionality changes: the job still checks out code and runs pylint, which only need read access. Concretely, in `.github/workflows/pylint.yml`, insert the `permissions` section between the `on: [push]` line and the `jobs:` block. No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
