### PR TITLE
Add Python Playwright e2e test suite and CI workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,36 @@
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python and uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: uv pip install --system -r requirements.txt -r e2e/requirements.txt
+      - name: Install Playwright browsers
+        run: playwright install --with-deps chromium
+      - name: Run e2e tests
+        run: pytest e2e/tests -v
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,11 +22,13 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: uv pip install --system -r requirements.txt -r e2e/requirements.txt
+        run: |
+          uv venv
+          uv pip install -r requirements.txt -r e2e/requirements.txt
       - name: Install Playwright browsers
-        run: playwright install --with-deps chromium
+        run: uv run playwright install --with-deps chromium
       - name: Run e2e tests
-        run: pytest e2e/tests -v
+        run: uv run pytest e2e/tests -v
       - name: Upload Playwright artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install pylint -r requirements.txt -r e2e/requirements.txt
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,2 @@
 [MAIN]
-init-hook='import sys; sys.path.insert(0, "src")'
+init-hook='import sys; sys.path.insert(0, "src"); sys.path.insert(0, "e2e")'

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -1,0 +1,36 @@
+# E2E Coverage Tracker
+
+Keep this file in sync with `e2e/tests/`. When you add or modify a test, update the
+matching row (or add a new one).
+
+Statuses: `Covered` | `Partial` | `Planned` | `N/A (unmerged)` | `N/A (no interactive surface)`
+
+**Before adding a row against a commit**, verify it is actually reachable from `main`:
+
+```
+git merge-base --is-ancestor <commit> HEAD && echo "on main" || echo "NOT on main"
+```
+
+Two rows below (#4 and #15) were only caught by this check — their commits exist in
+history but live on branches that were never merged, so no code for them exists on
+`main` and no test was written.
+
+| # | Feature / Bugfix | Commit(s) | Test file | Test name(s) | Status | Notes |
+|---|---|---|---|---|---|---|
+| 1 | Auth / dev-mode bypass | 45e3799, e4ec5c7 | `test_devmode_bootstrap.py` | `test_api_config_reports_dev_mode`, `test_login_view_is_skipped`, `test_drawer_shows_local_user`, `test_api_calls_carry_local_user_header` | Covered | |
+| 2 | Lunch/visit calendar core | f467a0d, 552e70d, e5a70ac | `test_calendar_core.py` | `test_default_month_is_current_month`, `test_monday_is_locked_to_pday`, `test_two_name_slots_persist_independently_after_reload`, `test_empty_padding_cells_render_without_inputs` | Covered | |
+| 3 | PDAY override / mute day | (core UI, undated) | `test_calendar_pday_and_mute.py` | `test_pday_override_moves_names_into_monday_preview`, `test_pday_override_can_be_reverted_by_reselecting_monday`, `test_mute_toggle_disables_inputs_for_that_day`, `test_mute_toggle_can_be_reverted` | Covered | |
+| 4 | Duplas Missionárias 3-couple slider | e5a70ac, c3c3459, 30e8730, 627da17, 69ea4b9 | — | — | N/A (unmerged) | Lives on `origin/copilot/add-third-missionary-option`, never merged to `main`. Current `renderCalendar()` hard-codes exactly 2 slots. Re-add coverage if/when merged. |
+| 5 | PNG export | (part of core calendar) | `test_calendar_download_png.py` | `test_download_produces_dated_png_and_status_message` | Covered | |
+| 6 | Multi-profile (Perfil) | 999ded9 | `test_multi_profile.py` | `test_exactly_two_profile_buttons`, `test_switching_profile_keeps_entries_independent`, `test_profile_outside_configured_range_is_rejected_by_the_api` | Covered | |
+| 7 | Ward setting / per-profile title-subtitle | 496892f | `test_settings_ward_and_titles.py` | `test_settings_modal_prefills_current_ward`, `test_save_persists_ward_and_profile_title_after_reload`, `test_cancel_discards_unsaved_edits` | Covered | |
+| 8 | Baptismal Plan CRUD | 6107848 | `test_baptismal_plan_crud.py` | `test_empty_state_shown_with_no_plans`, `test_new_plan_appears_in_list_with_default_status`, `test_editing_details_autosaves`, `test_add_candidate_autosaves_and_populates_ordinances_section`, `test_remove_candidate_autosaves`, `test_delete_plan_removes_it_and_shows_empty_state`, `test_switching_between_existing_plans_loads_correct_data`, `test_reload_persists_plan_data` | Covered | |
+| 9 | Baptismal Plan PDF export | 6107848 | `test_baptismal_plan_export_pdf.py` | `test_export_opens_popup_with_plan_content` | Covered | Only asserts popup content, not the native OS print dialog (not automatable in headless Chromium). |
+| 10 | Side navigation drawer | 85ebcd9 | `test_side_drawer_navigation.py` | `test_drawer_starts_closed`, `test_menu_button_opens_and_backdrop_closes_drawer`, `test_nav_items_are_calendar_and_baptismal_plan`, `test_navigating_switches_view_and_closes_drawer`, `test_dev_mode_sign_out_closes_drawer_without_error` | Covered | |
+| 11 | Mobile/responsive UI | ce4aeca, d42be9c | `test_responsive_mobile.py` | `test_menu_button_visible_and_drawer_overlays`, `test_calendar_table_scrolls_horizontally_on_mobile` | Partial | Structural/behavioral checks only, no pixel snapshots. |
+| 12 | Loading states | 8bd0b8d | `test_loading_states.py` | `test_calendar_spinner_shows_while_initial_data_loads`, `test_baptismal_plan_save_status_transitions_while_saving` | Covered | Uses `page.route` to inject artificial delay. |
+| 13 | Data persistence: clearing a field | b593f26 | `test_persistence_regressions.py` | `test_clearing_a_cell_persists_as_empty` | Covered | Explicit regression test. |
+| 14 | Calendar cell overflow | 1bd7879 | `test_persistence_regressions.py` | `test_long_names_do_not_overflow_the_cell` | Partial | Fuzzy bounding-box comparison, not a strict CSS regression test. |
+| 15 | Deprecation notice | bf08145 | — | — | N/A (unmerged) | Lives on `origin/deprecated-v0.4`, never merged to `main`. No such element exists. |
+| 16 | Dark mode | 552e70d | `test_ui_smoke.py` | `test_color_scheme_is_dark` | Covered | Static `color-scheme: dark` CSS rule — no interactive toggle exists in the current UI. |
+| 17 | Favicon/branding & page title | 857dded | `test_ui_smoke.py` | `test_page_title`, `test_favicon_link_and_asset` | Covered | |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,68 @@
+# E2E Tests
+
+Python Playwright end-to-end tests for Mission Leader Assistant, driving the real app
+in a browser against a live server started with `--dev` (JSON storage, no Google
+credentials needed, login is auto-bypassed).
+
+## Install
+
+Uses [`uv`](https://docs.astral.sh/uv/) for package management:
+
+```bash
+uv pip install --system -r requirements.txt -r e2e/requirements.txt
+playwright install --with-deps chromium
+```
+
+Or, for an isolated local virtual environment:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -r requirements.txt -r e2e/requirements.txt
+playwright install --with-deps chromium
+```
+
+## Run
+
+From the repo root:
+
+```bash
+pytest e2e/tests -v
+```
+
+Run a subset with `-k`:
+
+```bash
+pytest e2e/tests -v -k baptismal_plan
+```
+
+## Debug
+
+Run headed, with slow-motion, to watch the browser:
+
+```bash
+pytest e2e/tests --headed --slowmo 200
+```
+
+On failure, screenshots/videos/traces are written to `test-results/` (see
+`e2e/pytest.ini`). Open a trace with:
+
+```bash
+playwright show-trace test-results/<test-name>/trace.zip
+```
+
+## How it works
+
+- `fixtures/server.py` starts `src/app.py --dev` once per test session as a
+  subprocess, on a free port, with its working directory set to a throwaway temp
+  directory — so the suite never touches your real local `calendar_data.json`.
+- `fixtures/data.py` deletes that isolated data file before every test, so each test
+  starts from a clean slate without needing to restart the server.
+- `pages/` holds Page Object Model wrappers for each view (calendar, settings modal,
+  baptismal plan, side drawer).
+- Dev mode bypasses Firebase login entirely (hardcoded `X-User-Id: local`), so no
+  login flow is needed to reach the app.
+
+## Coverage
+
+See [`COVERAGE.md`](COVERAGE.md) for the feature/bugfix-to-test mapping.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,14 +6,9 @@ credentials needed, login is auto-bypassed).
 
 ## Install
 
-Uses [`uv`](https://docs.astral.sh/uv/) for package management:
-
-```bash
-uv pip install --system -r requirements.txt -r e2e/requirements.txt
-playwright install --with-deps chromium
-```
-
-Or, for an isolated local virtual environment:
+Uses [`uv`](https://docs.astral.sh/uv/) for package management. Most Linux distros
+(and GitHub Actions runners) mark the system Python as externally managed, so create
+a venv first rather than installing with `--system`:
 
 ```bash
 uv venv
@@ -24,7 +19,7 @@ playwright install --with-deps chromium
 
 ## Run
 
-From the repo root:
+From the repo root (with the venv above activated):
 
 ```bash
 pytest e2e/tests -v

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,65 @@
+"""Shared pytest fixtures for the Playwright e2e suite.
+
+pytest inserts this directory (e2e/, which has no __init__.py) onto sys.path, which
+is what makes `fixtures` and `pages` importable as top-level packages below.
+"""
+import pytest
+
+from fixtures.data import reset_data  # noqa: F401  (re-exported as an autouse fixture)
+from fixtures.server import live_server  # noqa: F401  (re-exported for direct use in tests)
+from pages.baptismal_plan_page import BaptismalPlanPage
+from pages.calendar_page import CalendarPage
+from pages.side_drawer import SideDrawer
+
+
+@pytest.fixture
+def calendar_page(reset_data, live_server, page):  # pylint: disable=unused-argument
+    """Load the app and return once dev-mode bootstrap has landed on the calendar view.
+
+    Depends explicitly on `reset_data` (rather than relying on its autouse ordering)
+    so the isolated data file is always wiped before this fixture's initial page load
+    fetches anything — otherwise a same-session ordering race can let a later test's
+    first fetch pick up data left behind by an earlier test.
+    """
+    page.goto(live_server.base_url)
+    page.wait_for_selector("#calendarView:not(.hidden)")
+    return CalendarPage(page)
+
+
+@pytest.fixture
+def baptismal_plan_page(calendar_page):
+    """Navigate from the calendar view into the baptismal plan view via the side drawer."""
+    calendar_page.navigate_to("/baptismal-plan")
+    calendar_page.page.wait_for_selector("#baptismalPlanView:not(.hidden)")
+    return BaptismalPlanPage(calendar_page.page)
+
+
+@pytest.fixture
+def side_drawer(calendar_page):
+    """Return a SideDrawer bound to the same page as `calendar_page`."""
+    return SideDrawer(calendar_page.page)
+
+
+@pytest.fixture
+def slow_network(page):
+    """Add artificial latency to every request on `page` via CDP network emulation.
+
+    A `page.route()` handler that blocks with `time.sleep()` seems like the obvious
+    way to simulate a slow request, but it doesn't work here: Playwright's sync API
+    runs on a single greenlet-based dispatcher thread, and a blocking sleep inside a
+    route handler stalls that same thread — which also stalls every other Python-side
+    Playwright call (including the ones a test would use to observe the resulting
+    "loading" state) for the same duration. CDP-level throttling delays requests
+    inside the browser process itself, so Python-side calls stay responsive.
+    """
+    session = page.context.new_cdp_session(page)
+    session.send("Network.enable")
+    session.send(
+        "Network.emulateNetworkConditions",
+        {"offline": False, "latency": 300, "downloadThroughput": -1, "uploadThroughput": -1},
+    )
+    yield
+    session.send(
+        "Network.emulateNetworkConditions",
+        {"offline": False, "latency": 0, "downloadThroughput": -1, "uploadThroughput": -1},
+    )

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -5,15 +5,19 @@ is what makes `fixtures` and `pages` importable as top-level packages below.
 """
 import pytest
 
-from fixtures.data import reset_data  # noqa: F401  (re-exported as an autouse fixture)
-from fixtures.server import live_server  # noqa: F401  (re-exported for direct use in tests)
+# Re-exported so pytest can discover them as fixtures; also used directly below.
+from fixtures.data import reset_data  # pylint: disable=unused-import
+from fixtures.server import live_server  # pylint: disable=unused-import
 from pages.baptismal_plan_page import BaptismalPlanPage
 from pages.calendar_page import CalendarPage
 from pages.side_drawer import SideDrawer
 
 
 @pytest.fixture
-def calendar_page(reset_data, live_server, page):  # pylint: disable=unused-argument
+# pytest fixtures conventionally shadow their own imported names; that's the
+# whole mechanism, not a real name collision.
+# pylint: disable=redefined-outer-name,unused-argument
+def calendar_page(reset_data, live_server, page):
     """Load the app and return once dev-mode bootstrap has landed on the calendar view.
 
     Depends explicitly on `reset_data` (rather than relying on its autouse ordering)
@@ -27,7 +31,7 @@ def calendar_page(reset_data, live_server, page):  # pylint: disable=unused-argu
 
 
 @pytest.fixture
-def baptismal_plan_page(calendar_page):
+def baptismal_plan_page(calendar_page):  # pylint: disable=redefined-outer-name
     """Navigate from the calendar view into the baptismal plan view via the side drawer."""
     calendar_page.navigate_to("/baptismal-plan")
     calendar_page.page.wait_for_selector("#baptismalPlanView:not(.hidden)")
@@ -35,7 +39,7 @@ def baptismal_plan_page(calendar_page):
 
 
 @pytest.fixture
-def side_drawer(calendar_page):
+def side_drawer(calendar_page):  # pylint: disable=redefined-outer-name
     """Return a SideDrawer bound to the same page as `calendar_page`."""
     return SideDrawer(calendar_page.page)
 

--- a/e2e/fixtures/data.py
+++ b/e2e/fixtures/data.py
@@ -27,7 +27,9 @@ def seed_baptismal_plan(request_context, base_url, payload=None):
     Bypasses the UI for tests that need pre-existing plans (e.g. switching between
     multiple plans) without depending on the create-plan flow under test elsewhere.
     """
-    create_response = request_context.post(f"{base_url}/api/baptismal-plans", headers=USER_HEADERS, data={})
+    create_response = request_context.post(
+        f"{base_url}/api/baptismal-plans", headers=USER_HEADERS, data={}
+    )
     assert create_response.ok, create_response.text()
     plan = create_response.json()["plan"]
     if payload:

--- a/e2e/fixtures/data.py
+++ b/e2e/fixtures/data.py
@@ -1,0 +1,52 @@
+"""Per-test data isolation and API seeding helpers for the baptismal plan feature."""
+import pytest
+
+USER_HEADERS = {"X-User-Id": "local"}
+
+
+@pytest.fixture(autouse=True)
+def reset_data(live_server):
+    """Delete both isolated data files before every test so each test starts clean.
+
+    The calendar store and the baptismal-plan store write to two separate files
+    (see LiveServer in fixtures/server.py) — both must be removed, or baptismal
+    plan data leaks across tests. Both JsonFileStore classes re-read from disk on
+    every call (no in-process cache), so this is safe without restarting the
+    session-scoped server.
+    """
+    if live_server.data_file.exists():
+        live_server.data_file.unlink()
+    if live_server.baptismal_plan_data_file.exists():
+        live_server.baptismal_plan_data_file.unlink()
+    yield
+
+
+def seed_baptismal_plan(request_context, base_url, payload=None):
+    """Create a baptismal plan via the API, optionally updating it with `payload`.
+
+    Bypasses the UI for tests that need pre-existing plans (e.g. switching between
+    multiple plans) without depending on the create-plan flow under test elsewhere.
+    """
+    create_response = request_context.post(f"{base_url}/api/baptismal-plans", headers=USER_HEADERS, data={})
+    assert create_response.ok, create_response.text()
+    plan = create_response.json()["plan"]
+    if payload:
+        update_response = request_context.put(
+            f"{base_url}/api/baptismal-plans/{plan['id']}",
+            headers=USER_HEADERS,
+            data=payload,
+        )
+        assert update_response.ok, update_response.text()
+        plan = update_response.json()["plan"]
+    return plan
+
+
+def get_calendar_payload(request_context, base_url, year, month, profile=1):
+    """Fetch the raw /api/calendar JSON payload for the given month, as the app itself would."""
+    response = request_context.get(
+        f"{base_url}/api/calendar",
+        headers=USER_HEADERS,
+        params={"year": str(year), "month": str(month), "profile": str(profile)},
+    )
+    assert response.ok, response.text()
+    return response.json()

--- a/e2e/fixtures/server.py
+++ b/e2e/fixtures/server.py
@@ -1,0 +1,91 @@
+"""Subprocess lifecycle management for the live app server used by e2e tests."""
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_ENTRYPOINT = REPO_ROOT / "src" / "app.py"
+READY_TIMEOUT_SECONDS = 10
+READY_POLL_INTERVAL_SECONDS = 0.1
+
+
+@dataclass
+class LiveServer:
+    """A running instance of the app, started in --dev mode for e2e tests."""
+
+    base_url: str
+    process: subprocess.Popen
+    data_file: Path
+    baptismal_plan_data_file: Path
+
+
+def _free_port() -> int:
+    """Return a currently-unused TCP port by binding to port 0 and releasing it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_until_ready(process: subprocess.Popen, config_url: str) -> None:
+    """Poll `config_url` until it responds or the process exits/times out."""
+    deadline = time.monotonic() + READY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            output = process.stdout.read() if process.stdout else ""
+            raise RuntimeError(f"App server exited early (code {process.returncode}):\n{output}")
+        try:
+            with urllib.request.urlopen(config_url, timeout=1) as response:
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, ConnectionError):
+            pass
+        time.sleep(READY_POLL_INTERVAL_SECONDS)
+    process.kill()
+    output = process.stdout.read() if process.stdout else ""
+    raise RuntimeError(f"App server did not become ready in time:\n{output}")
+
+
+@pytest.fixture(scope="session")
+def live_server(tmp_path_factory):
+    """Start the app once for the whole test session, isolated from the developer's real data.
+
+    The data file resolves relative to the process CWD (see JsonFileStore in
+    src/core/store.py), so launching with cwd set to a throwaway temp dir keeps
+    e2e runs from ever touching the real calendar_data.json.
+    """
+    data_dir = tmp_path_factory.mktemp("e2e-data")
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    process = subprocess.Popen(  # pylint: disable=consider-using-with
+        [sys.executable, str(APP_ENTRYPOINT), "--dev", "--host", "127.0.0.1", "--port", str(port)],
+        cwd=data_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    _wait_until_ready(process, base_url + "/api/config")
+
+    # BaptismalPlanJsonStore writes to a sibling "<stem>_baptismal_plans.<ext>" file
+    # rather than calendar_data.json itself (see create_baptismal_plan_store in
+    # src/core/store.py) — both must be tracked so tests can reset both stores.
+    yield LiveServer(
+        base_url=base_url,
+        process=process,
+        data_file=data_dir / "calendar_data.json",
+        baptismal_plan_data_file=data_dir / "calendar_data_baptismal_plans.json",
+    )
+
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)

--- a/e2e/pages/baptismal_plan_page.py
+++ b/e2e/pages/baptismal_plan_page.py
@@ -1,4 +1,5 @@
 """Page object for the baptismal plan view (#baptismalPlanView)."""
+# pylint: disable=missing-function-docstring
 from .base_page import BasePage
 
 # Autosave round-trips against the local dev server complete in well under
@@ -49,8 +50,10 @@ class BaptismalPlanPage(BasePage):
         self.page.once("dialog", lambda dialog: dialog.accept())
         self.page.click(f'.bp-plan-item[data-plan-id="{plan_id}"] .bp-plan-item-delete')
 
-    def fill_details(self, *, service_date=None, service_time=None, ward=None,
-                      location=None, conducting_leader=None, status=None):
+    # One optional kwarg per form field is clearer here than bundling them into a
+    # dict/dataclass for a test helper.
+    def fill_details(self, *, service_date=None, service_time=None,  # pylint: disable=too-many-arguments
+                      ward=None, location=None, conducting_leader=None, status=None):
         fields = {
             "#bpServiceDate": service_date,
             "#bpServiceTime": service_time,

--- a/e2e/pages/baptismal_plan_page.py
+++ b/e2e/pages/baptismal_plan_page.py
@@ -1,0 +1,108 @@
+"""Page object for the baptismal plan view (#baptismalPlanView)."""
+from .base_page import BasePage
+
+# Autosave round-trips against the local dev server complete in well under
+# 200ms (confirmed via network inspection). Reactive waits on the transient
+# "Salvo" status text (both `page.wait_for_function` and `page.expect_response`)
+# proved unreliable specifically for saves triggered from a locator scoped inside
+# a re-rendered candidate card — they would time out even though the save had
+# already completed and the DOM had genuinely already updated. A fixed delay with
+# generous headroom sidesteps that without depending on unclear Playwright/DOM
+# timing behavior in this one scenario.
+_SAVE_ROUNDTRIP_MS = 600
+
+
+class BaptismalPlanPage(BasePage):
+    """Wraps the plan list, editor form, candidates, and PDF export.
+
+    Autosave fires one request per field blur/change. Editing several fields back
+    to back would fire several overlapping autosaves (each snapshotting the full
+    form at call time), and since responses can arrive out of order, a later,
+    fresher save could be overwritten in the UI by an earlier, staler one that
+    resolves after it. `fill_details`/`fill_candidate` avoid that by waiting for
+    each field's own save to complete before touching the next field, so saves
+    are always sent — and confirmed — one at a time.
+    """
+
+    def empty_state_visible(self):
+        return self.page.locator("#bpEmptyState").is_visible()
+
+    def editor_visible(self):
+        return self.page.locator("#bpEditorContent").is_visible()
+
+    def new_plan(self):
+        self.page.click("#bpNewPlanBtn")
+        self.page.wait_for_selector("#bpEditorContent:not(.hidden)")
+
+    def plan_items(self):
+        return self.page.locator(".bp-plan-item[data-plan-id]")
+
+    def select_plan(self, plan_id):
+        self.page.click(f'.bp-plan-item[data-plan-id="{plan_id}"] .bp-plan-item-content')
+        self.page.wait_for_selector("#bpEditorContent:not(.hidden)")
+        # `networkidle` proved unreliable for this SPA-style, JS-triggered fetch
+        # (it can resolve before the request is even dispatched) — see
+        # `_SAVE_ROUNDTRIP_MS` above for the same issue in the autosave path.
+        self.wait_for_saved()
+
+    def delete_plan(self, plan_id):
+        self.page.once("dialog", lambda dialog: dialog.accept())
+        self.page.click(f'.bp-plan-item[data-plan-id="{plan_id}"] .bp-plan-item-delete')
+
+    def fill_details(self, *, service_date=None, service_time=None, ward=None,
+                      location=None, conducting_leader=None, status=None):
+        fields = {
+            "#bpServiceDate": service_date,
+            "#bpServiceTime": service_time,
+            "#bpWard": ward,
+            "#bpLocation": location,
+            "#bpConductingLeader": conducting_leader,
+        }
+        for selector, value in fields.items():
+            if value is not None:
+                self.page.fill(selector, value)
+                self.page.locator(selector).blur()
+                self.wait_for_saved()
+        if status is not None:
+            self.page.select_option("#bpStatus", status)
+            self.wait_for_saved()
+
+    def add_candidate(self):
+        self.page.click("#bpAddCandidateBtn")
+        self.wait_for_saved()
+
+    def candidate_cards(self):
+        return self.page.locator(".bp-candidate-card")
+
+    def fill_candidate(self, card_index, *, full_name=None, birth_date=None, candidate_type=None):
+        card = self.candidate_cards().nth(card_index)
+        if full_name is not None:
+            card.locator(".bp-c-fullName").fill(full_name)
+            card.locator(".bp-c-fullName").blur()
+            self.wait_for_saved()
+        if birth_date is not None:
+            card.locator(".bp-c-birthDate").fill(birth_date)
+            card.locator(".bp-c-birthDate").blur()
+            self.wait_for_saved()
+        if candidate_type is not None:
+            card.locator(".bp-c-candidateType").select_option(candidate_type)
+            self.wait_for_saved()
+
+    def remove_candidate(self, card_index):
+        self.candidate_cards().nth(card_index).locator(".bp-remove-candidate").click()
+        self.wait_for_saved()
+
+    def ordinances_witnesses_empty_note_visible(self):
+        return self.page.locator("#bpOrdinancesWitnessesEmpty").is_visible()
+
+    def export_pdf(self):
+        with self.page.expect_popup() as popup_info:
+            self.page.click("#bpExportPdfBtn")
+        return popup_info.value
+
+    def save_status_text(self):
+        return self.page.locator("#bpSaveStatus").text_content()
+
+    def wait_for_saved(self):
+        """Wait for an in-flight autosave to complete. See `_SAVE_ROUNDTRIP_MS`."""
+        self.page.wait_for_timeout(_SAVE_ROUNDTRIP_MS)

--- a/e2e/pages/base_page.py
+++ b/e2e/pages/base_page.py
@@ -1,0 +1,23 @@
+"""Shared helpers for all page objects in the e2e suite."""
+
+
+class BasePage:
+    """Wraps a Playwright Page with drawer/navigation helpers common to every view."""
+
+    def __init__(self, page):
+        self.page = page
+
+    def open_drawer(self):
+        """Open the side navigation drawer via the hamburger button."""
+        self.page.click("#menuToggleBtn")
+        self.page.wait_for_selector("#sideDrawer.open")
+
+    def close_drawer_via_backdrop(self):
+        """Close the side navigation drawer by clicking outside it."""
+        self.page.click("#drawerBackdrop")
+        self.page.wait_for_selector("#sideDrawer:not(.open)")
+
+    def navigate_to(self, route):
+        """Open the drawer and click the nav item for the given route (e.g. "/baptismal-plan")."""
+        self.open_drawer()
+        self.page.click(f'.nav-item[data-route="{route}"]')

--- a/e2e/pages/calendar_page.py
+++ b/e2e/pages/calendar_page.py
@@ -1,4 +1,5 @@
 """Page object for the lunch/visit calendar view (#calendarView)."""
+# pylint: disable=missing-function-docstring
 from .base_page import BasePage
 
 
@@ -12,9 +13,9 @@ class CalendarPage(BasePage):
     """
 
     def day_cell(self, day_of_week, week_number=2):
-        return self.page.locator(
-            f'#calendarBody tr[data-week-number="{week_number}"] td[data-day-of-week="{day_of_week}"]'
-        )
+        row = f'tr[data-week-number="{week_number}"]'
+        cell = f'td[data-day-of-week="{day_of_week}"]'
+        return self.page.locator(f"#calendarBody {row} {cell}")
 
     def name_input(self, day_of_week, slot=1, week_number=2):
         cell = self.day_cell(day_of_week, week_number)

--- a/e2e/pages/calendar_page.py
+++ b/e2e/pages/calendar_page.py
@@ -1,0 +1,60 @@
+"""Page object for the lunch/visit calendar view (#calendarView)."""
+from .base_page import BasePage
+
+
+class CalendarPage(BasePage):
+    """Wraps interactions with the calendar table, profile switcher, and PNG export.
+
+    Week 2 (rows are 1-indexed via `data-week-number`) always covers real calendar
+    days ~2..14 of the month regardless of which weekday the month starts on, so it
+    is used as the default "guaranteed populated" week across tests instead of week 1
+    (which can contain empty padding cells depending on the month's start weekday).
+    """
+
+    def day_cell(self, day_of_week, week_number=2):
+        return self.page.locator(
+            f'#calendarBody tr[data-week-number="{week_number}"] td[data-day-of-week="{day_of_week}"]'
+        )
+
+    def name_input(self, day_of_week, slot=1, week_number=2):
+        cell = self.day_cell(day_of_week, week_number)
+        selector = ".name-input.secondary" if slot == 2 else ".name-input:not(.secondary)"
+        return cell.locator(selector)
+
+    def fill_name(self, day_of_week, name, slot=1, week_number=2):
+        field = self.name_input(day_of_week, slot, week_number)
+        field.fill(name)
+        field.blur()
+
+    def switch_profile(self, profile):
+        with self.page.expect_response(
+            lambda r: "/api/calendar" in r.url and f"profile={profile}" in r.url
+        ):
+            self.page.click(f'#topbarSlotSwitcher .slot-btn[data-profile="{profile}"]')
+
+    def active_profile_button(self):
+        return self.page.locator("#topbarSlotSwitcher .slot-btn.active")
+
+    def open_settings(self):
+        self.page.click("#settingsBtn")
+        self.page.wait_for_selector("#settingsModal:not(.hidden)")
+
+    def download_png(self):
+        with self.page.expect_download() as download_info:
+            self.page.click("#downloadBtn")
+        return download_info.value
+
+    def toggle_pday(self, day_of_week, week_number=2):
+        self.day_cell(day_of_week, week_number).locator(".pday-toggle").click()
+
+    def toggle_mute(self, day_of_week, week_number=2):
+        self.day_cell(day_of_week, week_number).locator(".mute-toggle").click()
+
+    def monday_preview_text(self, week_number=2):
+        return self.day_cell("Monday", week_number).locator(".monday-preview").text_content()
+
+    def monday_fixed_visible(self, week_number=2):
+        return self.day_cell("Monday", week_number).locator(".fixed-name").is_visible()
+
+    def status_text(self):
+        return self.page.locator("#statusText").text_content()

--- a/e2e/pages/settings_modal.py
+++ b/e2e/pages/settings_modal.py
@@ -1,0 +1,31 @@
+"""Page object for the settings modal (#settingsModal)."""
+
+
+class SettingsModal:
+    """Wraps the ward + per-profile title/subtitle settings form."""
+
+    def __init__(self, page):
+        self.page = page
+
+    def ward_value(self):
+        return self.page.locator("#wardInput").input_value()
+
+    def set_ward(self, ward):
+        self.page.fill("#wardInput", ward)
+
+    def switch_edit_profile(self, profile):
+        self.page.click(f'.modal-slot-switcher .slot-btn[data-settings-profile="{profile}"]')
+
+    def set_title(self, title):
+        self.page.fill("#slotTitleInput", title)
+
+    def set_subtitle(self, subtitle):
+        self.page.fill("#slotSubtitleInput", subtitle)
+
+    def save(self):
+        self.page.click("#saveSettingsBtn")
+        self.page.wait_for_selector("#settingsModal.hidden", state="attached")
+
+    def cancel(self):
+        self.page.click("#cancelSettingsBtn")
+        self.page.wait_for_selector("#settingsModal.hidden", state="attached")

--- a/e2e/pages/settings_modal.py
+++ b/e2e/pages/settings_modal.py
@@ -1,4 +1,5 @@
 """Page object for the settings modal (#settingsModal)."""
+# pylint: disable=missing-function-docstring
 
 
 class SettingsModal:

--- a/e2e/pages/side_drawer.py
+++ b/e2e/pages/side_drawer.py
@@ -1,0 +1,24 @@
+"""Page object for the side navigation drawer (#sideDrawer)."""
+
+
+class SideDrawer:
+    """Wraps the collapsible navigation drawer and its footer user panel."""
+
+    def __init__(self, page):
+        self.page = page
+
+    def is_open(self):
+        classes = self.page.locator("#sideDrawer").get_attribute("class") or ""
+        return "open" in classes.split()
+
+    def nav_item_labels(self):
+        return self.page.locator("#sideDrawer .nav-item").all_inner_texts()
+
+    def active_route(self):
+        return self.page.locator("#sideDrawer .nav-item.active").get_attribute("data-route")
+
+    def user_name(self):
+        return self.page.locator("#drawerUserName").text_content()
+
+    def sign_out(self):
+        self.page.click("#drawerSignOutBtn")

--- a/e2e/pages/side_drawer.py
+++ b/e2e/pages/side_drawer.py
@@ -1,4 +1,5 @@
 """Page object for the side navigation drawer (#sideDrawer)."""
+# pylint: disable=missing-function-docstring
 
 
 class SideDrawer:

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = --browser chromium --screenshot only-on-failure --video retain-on-failure --tracing retain-on-failure

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,0 +1,3 @@
+pytest>=8.0
+pytest-playwright>=0.5
+playwright>=1.45

--- a/e2e/tests/test_baptismal_plan_crud.py
+++ b/e2e/tests/test_baptismal_plan_crud.py
@@ -1,6 +1,7 @@
 """Covers the Baptismal Plan (Planejamento Batismal) CRUD feature (commit 6107848):
 create/edit/delete plans, candidates, and reload persistence.
 """
+# pylint: disable=missing-function-docstring
 from fixtures.data import seed_baptismal_plan
 from pages.baptismal_plan_page import BaptismalPlanPage
 from pages.calendar_page import CalendarPage

--- a/e2e/tests/test_baptismal_plan_crud.py
+++ b/e2e/tests/test_baptismal_plan_crud.py
@@ -1,0 +1,97 @@
+"""Covers the Baptismal Plan (Planejamento Batismal) CRUD feature (commit 6107848):
+create/edit/delete plans, candidates, and reload persistence.
+"""
+from fixtures.data import seed_baptismal_plan
+from pages.baptismal_plan_page import BaptismalPlanPage
+from pages.calendar_page import CalendarPage
+
+
+def test_empty_state_shown_with_no_plans(baptismal_plan_page):
+    assert baptismal_plan_page.empty_state_visible()
+    assert not baptismal_plan_page.editor_visible()
+
+
+def test_new_plan_appears_in_list_with_default_status(baptismal_plan_page):
+    baptismal_plan_page.new_plan()
+
+    assert baptismal_plan_page.editor_visible()
+    items = baptismal_plan_page.plan_items()
+    assert items.count() == 1
+    assert "Rascunho" in items.first.text_content()
+    assert "Sem candidatos" in items.first.text_content()
+
+
+def test_editing_details_autosaves(baptismal_plan_page):
+    baptismal_plan_page.new_plan()
+    baptismal_plan_page.fill_details(
+        service_date="2026-08-15", ward="Eusebio", status="Scheduled"
+    )
+
+    assert "Agendado" in baptismal_plan_page.plan_items().first.text_content()
+
+
+def test_add_candidate_autosaves_and_populates_ordinances_section(baptismal_plan_page):
+    baptismal_plan_page.new_plan()
+    assert baptismal_plan_page.ordinances_witnesses_empty_note_visible()
+
+    baptismal_plan_page.add_candidate()
+    assert baptismal_plan_page.candidate_cards().count() == 1
+    assert not baptismal_plan_page.ordinances_witnesses_empty_note_visible()
+
+    baptismal_plan_page.fill_candidate(0, full_name="Joao Silva", candidate_type="Convert")
+    assert "Joao Silva" in baptismal_plan_page.plan_items().first.text_content()
+
+
+def test_remove_candidate_autosaves(baptismal_plan_page):
+    baptismal_plan_page.new_plan()
+    baptismal_plan_page.add_candidate()
+
+    baptismal_plan_page.remove_candidate(0)
+    assert baptismal_plan_page.candidate_cards().count() == 0
+    assert baptismal_plan_page.ordinances_witnesses_empty_note_visible()
+
+
+def test_delete_plan_removes_it_and_shows_empty_state(baptismal_plan_page):
+    baptismal_plan_page.new_plan()
+    plan_id = baptismal_plan_page.plan_items().first.get_attribute("data-plan-id")
+
+    baptismal_plan_page.delete_plan(plan_id)
+    baptismal_plan_page.page.wait_for_selector("#bpEmptyState:not(.hidden)")
+
+    assert baptismal_plan_page.plan_items().count() == 0
+    assert baptismal_plan_page.empty_state_visible()
+
+
+def test_switching_between_existing_plans_loads_correct_data(calendar_page, context, live_server):
+    plan_a = seed_baptismal_plan(
+        context.request, live_server.base_url, {"serviceDate": "2026-01-10", "ward": "Ala A"}
+    )
+    plan_b = seed_baptismal_plan(
+        context.request, live_server.base_url, {"serviceDate": "2026-02-20", "ward": "Ala B"}
+    )
+
+    calendar_page.navigate_to("/baptismal-plan")
+    calendar_page.page.wait_for_selector("#baptismalPlanView:not(.hidden)")
+    bp_page = BaptismalPlanPage(calendar_page.page)
+
+    bp_page.select_plan(plan_a["id"])
+    assert bp_page.page.locator("#bpWard").input_value() == "Ala A"
+
+    bp_page.select_plan(plan_b["id"])
+    assert bp_page.page.locator("#bpWard").input_value() == "Ala B"
+
+
+def test_reload_persists_plan_data(baptismal_plan_page, live_server):
+    baptismal_plan_page.new_plan()
+    plan_id = baptismal_plan_page.plan_items().first.get_attribute("data-plan-id")
+    baptismal_plan_page.fill_details(ward="Ala Persistente")
+
+    page = baptismal_plan_page.page
+    page.goto(live_server.base_url)
+    page.wait_for_selector("#calendarView:not(.hidden)")
+    CalendarPage(page).navigate_to("/baptismal-plan")
+    page.wait_for_selector("#baptismalPlanView:not(.hidden)")
+
+    reloaded = BaptismalPlanPage(page)
+    reloaded.select_plan(plan_id)
+    assert page.locator("#bpWard").input_value() == "Ala Persistente"

--- a/e2e/tests/test_baptismal_plan_export_pdf.py
+++ b/e2e/tests/test_baptismal_plan_export_pdf.py
@@ -1,0 +1,18 @@
+"""Covers Baptismal Plan PDF export (`#bpExportPdfBtn`, commit 6107848).
+
+The export opens a same-origin popup, writes a printable HTML document into it, and
+calls `window.print()` on load. Headless Chromium's print dialog cannot be driven by
+Playwright, so this only asserts on the popup's rendered document content.
+"""
+
+
+def test_export_opens_popup_with_plan_content(baptismal_plan_page):
+    baptismal_plan_page.new_plan()
+    baptismal_plan_page.add_candidate()
+    baptismal_plan_page.fill_candidate(0, full_name="Maria Oliveira")
+
+    popup = baptismal_plan_page.export_pdf()
+    popup.wait_for_load_state()
+
+    assert popup.locator("h1").text_content() == "Planejamento Batismal"
+    assert "Maria Oliveira" in popup.content()

--- a/e2e/tests/test_baptismal_plan_export_pdf.py
+++ b/e2e/tests/test_baptismal_plan_export_pdf.py
@@ -4,6 +4,7 @@ The export opens a same-origin popup, writes a printable HTML document into it, 
 calls `window.print()` on load. Headless Chromium's print dialog cannot be driven by
 Playwright, so this only asserts on the popup's rendered document content.
 """
+# pylint: disable=missing-function-docstring
 
 
 def test_export_opens_popup_with_plan_content(baptismal_plan_page):

--- a/e2e/tests/test_calendar_core.py
+++ b/e2e/tests/test_calendar_core.py
@@ -1,0 +1,56 @@
+"""Covers the core lunch/visit calendar (commits f467a0d, 552e70d, e5a70ac): rendering,
+saving both name slots, and the fixed/non-editable Monday "PDAY" cell.
+
+Week 2 is used throughout because it is guaranteed to contain real (non-padding)
+calendar days for any month (see CalendarPage docstring).
+"""
+from datetime import date
+
+from fixtures.data import get_calendar_payload
+
+
+def test_default_month_is_current_month(calendar_page):
+    today = date.today()
+    expected = f"{today.year:04d}-{today.month:02d}"
+    assert calendar_page.page.locator("#monthPicker").input_value() == expected
+
+
+def test_monday_is_locked_to_pday(calendar_page):
+    monday = calendar_page.day_cell("Monday")
+    assert monday.locator(".fixed-name").text_content().strip() == "PDAY"
+    assert monday.locator("input").count() == 0
+
+
+def test_two_name_slots_persist_independently_after_reload(calendar_page, live_server):
+    calendar_page.fill_name("Tuesday", "Familia Silva", slot=1)
+    calendar_page.fill_name("Tuesday", "Familia Souza", slot=2)
+
+    calendar_page.page.goto(live_server.base_url)
+    calendar_page.page.wait_for_selector("#calendarView:not(.hidden)")
+
+    assert calendar_page.name_input("Tuesday", slot=1).input_value() == "Familia Silva"
+    assert calendar_page.name_input("Tuesday", slot=2).input_value() == "Familia Souza"
+
+
+def test_empty_padding_cells_render_without_inputs(calendar_page, context, live_server):
+    # 2026-02 starts on a Sunday and has 28 days, so its display grid always has
+    # trailing padding cells (day_number is null) in the later weeks.
+    with calendar_page.page.expect_response(
+        lambda r: "/api/calendar" in r.url and "month=2" in r.url
+    ):
+        calendar_page.page.fill("#monthPicker", "2026-02")
+        calendar_page.page.dispatch_event("#monthPicker", "change")
+
+    payload = get_calendar_payload(context.request, live_server.base_url, year=2026, month=2)
+    # Monday always renders its fixed "PDAY" box regardless of day_number, so it
+    # never shows `.empty-day` — exclude it and look for a genuine padding cell.
+    empty_cell = next(
+        cell
+        for week in payload["weeks"]
+        for cell in week["cells"]
+        if cell["day_number"] is None and cell["day_of_week"] != "Monday"
+    )
+
+    dom_cell = calendar_page.day_cell(empty_cell["day_of_week"], week_number=empty_cell["week_number"])
+    assert dom_cell.locator(".empty-day").is_visible()
+    assert dom_cell.locator("input").count() == 0

--- a/e2e/tests/test_calendar_core.py
+++ b/e2e/tests/test_calendar_core.py
@@ -4,6 +4,7 @@ saving both name slots, and the fixed/non-editable Monday "PDAY" cell.
 Week 2 is used throughout because it is guaranteed to contain real (non-padding)
 calendar days for any month (see CalendarPage docstring).
 """
+# pylint: disable=missing-function-docstring
 from datetime import date
 
 from fixtures.data import get_calendar_payload
@@ -51,6 +52,8 @@ def test_empty_padding_cells_render_without_inputs(calendar_page, context, live_
         if cell["day_number"] is None and cell["day_of_week"] != "Monday"
     )
 
-    dom_cell = calendar_page.day_cell(empty_cell["day_of_week"], week_number=empty_cell["week_number"])
+    dom_cell = calendar_page.day_cell(
+        empty_cell["day_of_week"], week_number=empty_cell["week_number"]
+    )
     assert dom_cell.locator(".empty-day").is_visible()
     assert dom_cell.locator("input").count() == 0

--- a/e2e/tests/test_calendar_download_png.py
+++ b/e2e/tests/test_calendar_download_png.py
@@ -1,5 +1,6 @@
 """Covers the calendar PNG export (`#downloadBtn`), a pure-canvas client-side feature
 with no server/network dependency."""
+# pylint: disable=missing-function-docstring
 import re
 
 

--- a/e2e/tests/test_calendar_download_png.py
+++ b/e2e/tests/test_calendar_download_png.py
@@ -1,0 +1,12 @@
+"""Covers the calendar PNG export (`#downloadBtn`), a pure-canvas client-side feature
+with no server/network dependency."""
+import re
+
+
+def test_download_produces_dated_png_and_status_message(calendar_page):
+    calendar_page.fill_name("Tuesday", "Familia Lima", slot=1)
+
+    download = calendar_page.download_png()
+
+    assert re.fullmatch(r"calendar-\d{4}-\d{2}-\d{2}\.png", download.suggested_filename)
+    assert download.suggested_filename in calendar_page.status_text()

--- a/e2e/tests/test_calendar_pday_and_mute.py
+++ b/e2e/tests/test_calendar_pday_and_mute.py
@@ -1,6 +1,7 @@
 """Covers the per-week PDAY override ("P" button) and mute-day ("M" button) controls
 that live alongside the core calendar rendering.
 """
+# pylint: disable=missing-function-docstring
 
 
 def test_pday_override_moves_names_into_monday_preview(calendar_page):

--- a/e2e/tests/test_calendar_pday_and_mute.py
+++ b/e2e/tests/test_calendar_pday_and_mute.py
@@ -1,0 +1,36 @@
+"""Covers the per-week PDAY override ("P" button) and mute-day ("M" button) controls
+that live alongside the core calendar rendering.
+"""
+
+
+def test_pday_override_moves_names_into_monday_preview(calendar_page):
+    calendar_page.fill_name("Tuesday", "Familia Costa", slot=1)
+    calendar_page.toggle_pday("Tuesday")
+
+    assert "Familia Costa" in calendar_page.monday_preview_text()
+    assert not calendar_page.monday_fixed_visible()
+
+
+def test_pday_override_can_be_reverted_by_reselecting_monday(calendar_page):
+    calendar_page.fill_name("Tuesday", "Familia Costa", slot=1)
+    calendar_page.toggle_pday("Tuesday")
+    calendar_page.toggle_pday("Monday")
+
+    assert calendar_page.monday_fixed_visible()
+
+
+def test_mute_toggle_disables_inputs_for_that_day(calendar_page):
+    cell = calendar_page.day_cell("Wednesday")
+    calendar_page.toggle_mute("Wednesday")
+
+    assert "muted-active" in cell.locator(".cell").get_attribute("class")
+    for i in range(cell.locator("input").count()):
+        assert cell.locator("input").nth(i).is_disabled()
+
+
+def test_mute_toggle_can_be_reverted(calendar_page):
+    cell = calendar_page.day_cell("Wednesday")
+    calendar_page.toggle_mute("Wednesday")
+    calendar_page.toggle_mute("Wednesday")
+
+    assert "muted-active" not in cell.locator(".cell").get_attribute("class")

--- a/e2e/tests/test_devmode_bootstrap.py
+++ b/e2e/tests/test_devmode_bootstrap.py
@@ -1,6 +1,7 @@
 """Covers dev-mode auth bypass (commits 45e3799, e4ec5c7): the app skips Firebase
 login entirely when `--dev` is set, using a hardcoded "local" user identity.
 """
+# pylint: disable=missing-function-docstring
 
 
 def test_api_config_reports_dev_mode(context, live_server):
@@ -22,6 +23,10 @@ def test_drawer_shows_local_user(calendar_page, side_drawer):
 
 def test_api_calls_carry_local_user_header(live_server, page):
     requests = []
+    # Passing requests.append directly breaks Playwright's event handler
+    # registration (it inspects the callable in a way a bound builtin fails);
+    # wrapping it in a lambda is required, not just stylistic.
+    # pylint: disable-next=unnecessary-lambda
     page.on("request", lambda request: requests.append(request))
 
     page.goto(live_server.base_url)

--- a/e2e/tests/test_devmode_bootstrap.py
+++ b/e2e/tests/test_devmode_bootstrap.py
@@ -1,0 +1,32 @@
+"""Covers dev-mode auth bypass (commits 45e3799, e4ec5c7): the app skips Firebase
+login entirely when `--dev` is set, using a hardcoded "local" user identity.
+"""
+
+
+def test_api_config_reports_dev_mode(context, live_server):
+    response = context.request.get(f"{live_server.base_url}/api/config")
+    assert response.ok
+    assert response.json() == {"dev": True}
+
+
+def test_login_view_is_skipped(calendar_page):
+    assert calendar_page.page.locator("#loginView").is_hidden()
+    assert calendar_page.page.locator("#appNavBar").is_visible()
+    assert calendar_page.page.locator("#calendarView").is_visible()
+
+
+def test_drawer_shows_local_user(calendar_page, side_drawer):
+    calendar_page.open_drawer()
+    assert side_drawer.user_name().strip() == "local"
+
+
+def test_api_calls_carry_local_user_header(live_server, page):
+    requests = []
+    page.on("request", lambda request: requests.append(request))
+
+    page.goto(live_server.base_url)
+    page.wait_for_selector("#calendarView:not(.hidden)")
+
+    calendar_requests = [req for req in requests if "/api/calendar" in req.url]
+    assert calendar_requests
+    assert calendar_requests[0].headers.get("x-user-id") == "local"

--- a/e2e/tests/test_loading_states.py
+++ b/e2e/tests/test_loading_states.py
@@ -4,6 +4,7 @@ calendar status spinner and the baptismal-plan autosave status text.
 Both tests use the `slow_network` fixture (CDP-level request throttling) to create
 a window in which the transient "loading" state can be observed.
 """
+# pylint: disable=missing-function-docstring,unused-argument
 
 
 def test_calendar_spinner_shows_while_initial_data_loads(slow_network, live_server, page):

--- a/e2e/tests/test_loading_states.py
+++ b/e2e/tests/test_loading_states.py
@@ -1,0 +1,28 @@
+"""Covers loading-state indicators added for auth/API calls (commit 8bd0b8d): the
+calendar status spinner and the baptismal-plan autosave status text.
+
+Both tests use the `slow_network` fixture (CDP-level request throttling) to create
+a window in which the transient "loading" state can be observed.
+"""
+
+
+def test_calendar_spinner_shows_while_initial_data_loads(slow_network, live_server, page):
+    page.goto(live_server.base_url)
+
+    page.wait_for_selector("#statusSpinner:not(.hidden)")
+    page.wait_for_selector("#statusSpinner.hidden", state="attached", timeout=5000)
+
+
+def test_baptismal_plan_save_status_transitions_while_saving(slow_network, baptismal_plan_page):
+    baptismal_plan_page.new_plan()
+
+    # Trigger the save directly (not via fill_details, which waits for the save
+    # response before returning) so there is a window to observe "Salvando…".
+    page = baptismal_plan_page.page
+    page.fill("#bpWard", "Ala com Atraso")
+    page.locator("#bpWard").blur()
+
+    page.wait_for_function(
+        "document.getElementById('bpSaveStatus').textContent === 'Salvando…'"
+    )
+    baptismal_plan_page.wait_for_saved()

--- a/e2e/tests/test_multi_profile.py
+++ b/e2e/tests/test_multi_profile.py
@@ -1,6 +1,7 @@
 """Covers multi-profile (Perfil) calendar management (commit 999ded9): two independent
 calendars sharing the same UI, switched via the topbar slot buttons.
 """
+# pylint: disable=missing-function-docstring
 
 
 def test_exactly_two_profile_buttons(calendar_page):

--- a/e2e/tests/test_multi_profile.py
+++ b/e2e/tests/test_multi_profile.py
@@ -1,0 +1,33 @@
+"""Covers multi-profile (Perfil) calendar management (commit 999ded9): two independent
+calendars sharing the same UI, switched via the topbar slot buttons.
+"""
+
+
+def test_exactly_two_profile_buttons(calendar_page):
+    assert calendar_page.page.locator("#topbarSlotSwitcher .slot-btn").count() == 2
+
+
+def test_switching_profile_keeps_entries_independent(calendar_page):
+    calendar_page.fill_name("Tuesday", "Perfil Um", slot=1)
+
+    calendar_page.switch_profile(2)
+    assert calendar_page.active_profile_button().get_attribute("data-profile") == "2"
+    assert calendar_page.name_input("Tuesday", slot=1).input_value() == ""
+
+    calendar_page.fill_name("Tuesday", "Perfil Dois", slot=1)
+
+    calendar_page.switch_profile(1)
+    assert calendar_page.name_input("Tuesday", slot=1).input_value() == "Perfil Um"
+
+    calendar_page.switch_profile(2)
+    assert calendar_page.name_input("Tuesday", slot=1).input_value() == "Perfil Dois"
+
+
+def test_profile_outside_configured_range_is_rejected_by_the_api(context, live_server):
+    response = context.request.get(
+        f"{live_server.base_url}/api/calendar",
+        headers={"X-User-Id": "local"},
+        params={"year": "2026", "month": "1", "profile": "3"},
+    )
+    assert response.status == 400
+    assert "profile must be between 1 and 2" in response.json()["error"]

--- a/e2e/tests/test_persistence_regressions.py
+++ b/e2e/tests/test_persistence_regressions.py
@@ -1,0 +1,31 @@
+"""Regression tests tied to specific bug-fix commits."""
+
+
+def test_clearing_a_cell_persists_as_empty(calendar_page, live_server):
+    """Regression for commit b593f26: clearing a calendar field wasn't persisted,
+    so a reload would still show the stale name instead of an empty cell."""
+    calendar_page.fill_name("Thursday", "Familia Temporaria", slot=1)
+    calendar_page.page.goto(live_server.base_url)
+    calendar_page.page.wait_for_selector("#calendarView:not(.hidden)")
+    assert calendar_page.name_input("Thursday", slot=1).input_value() == "Familia Temporaria"
+
+    calendar_page.fill_name("Thursday", "", slot=1)
+    calendar_page.page.goto(live_server.base_url)
+    calendar_page.page.wait_for_selector("#calendarView:not(.hidden)")
+    assert calendar_page.name_input("Thursday", slot=1).input_value() == ""
+
+
+def test_long_names_do_not_overflow_the_cell(calendar_page):
+    """Regression for commit 1bd7879: calendar cell height caused input overflow.
+
+    This is an inherently fuzzy CSS assertion (bounding-box comparison), not a
+    strict functional check.
+    """
+    long_name = "Familia Extremamente Nome Comprido De Teste"
+    calendar_page.fill_name("Friday", long_name, slot=1)
+    calendar_page.fill_name("Friday", long_name, slot=2)
+
+    cell_box = calendar_page.day_cell("Friday").bounding_box()
+    input_box = calendar_page.name_input("Friday", slot=2).bounding_box()
+
+    assert input_box["y"] + input_box["height"] <= cell_box["y"] + cell_box["height"] + 1

--- a/e2e/tests/test_responsive_mobile.py
+++ b/e2e/tests/test_responsive_mobile.py
@@ -3,6 +3,7 @@
 Structural/behavioral checks only (element visibility, overlay behavior, scroll
 capability) rather than pixel snapshots, since the underlying commits are CSS-only.
 """
+# pylint: disable=missing-function-docstring
 import pytest
 
 

--- a/e2e/tests/test_responsive_mobile.py
+++ b/e2e/tests/test_responsive_mobile.py
@@ -1,0 +1,27 @@
+"""Covers mobile/tablet responsive UI fixes (commits ce4aeca, d42be9c).
+
+Structural/behavioral checks only (element visibility, overlay behavior, scroll
+capability) rather than pixel snapshots, since the underlying commits are CSS-only.
+"""
+import pytest
+
+
+@pytest.mark.parametrize("width,height", [(375, 667), (768, 1024)])
+def test_menu_button_visible_and_drawer_overlays(calendar_page, side_drawer, width, height):
+    calendar_page.page.set_viewport_size({"width": width, "height": height})
+
+    assert calendar_page.page.locator("#menuToggleBtn").is_visible()
+
+    calendar_page.open_drawer()
+    assert side_drawer.is_open()
+    drawer_box = calendar_page.page.locator("#sideDrawer").bounding_box()
+    assert drawer_box is not None
+
+
+def test_calendar_table_scrolls_horizontally_on_mobile(calendar_page):
+    calendar_page.page.set_viewport_size({"width": 375, "height": 667})
+
+    wrapper = calendar_page.page.locator(".table-scroll-wrapper")
+    scroll_width = wrapper.evaluate("el => el.scrollWidth")
+    client_width = wrapper.evaluate("el => el.clientWidth")
+    assert scroll_width > client_width

--- a/e2e/tests/test_settings_ward_and_titles.py
+++ b/e2e/tests/test_settings_ward_and_titles.py
@@ -1,0 +1,35 @@
+"""Covers the ward name and per-profile title/subtitle settings (commit 496892f)."""
+from pages.settings_modal import SettingsModal
+
+
+def test_settings_modal_prefills_current_ward(calendar_page):
+    calendar_page.open_settings()
+    modal = SettingsModal(calendar_page.page)
+    assert modal.ward_value() == ""
+
+
+def test_save_persists_ward_and_profile_title_after_reload(calendar_page, live_server):
+    calendar_page.open_settings()
+    modal = SettingsModal(calendar_page.page)
+    modal.set_ward("Eusebio")
+    modal.set_title("Calendario Customizado")
+    modal.set_subtitle("Subtitulo customizado")
+    modal.save()
+
+    assert calendar_page.page.locator("#calendarTitle").text_content() == "Calendario Customizado"
+    assert calendar_page.page.locator("#calendarSubtitle").text_content() == "Subtitulo customizado"
+
+    calendar_page.page.goto(live_server.base_url)
+    calendar_page.page.wait_for_selector("#calendarView:not(.hidden)")
+    calendar_page.open_settings()
+    assert SettingsModal(calendar_page.page).ward_value() == "Eusebio"
+
+
+def test_cancel_discards_unsaved_edits(calendar_page):
+    calendar_page.open_settings()
+    modal = SettingsModal(calendar_page.page)
+    modal.set_ward("Rascunho Nao Salvo")
+    modal.cancel()
+
+    calendar_page.open_settings()
+    assert SettingsModal(calendar_page.page).ward_value() == ""

--- a/e2e/tests/test_settings_ward_and_titles.py
+++ b/e2e/tests/test_settings_ward_and_titles.py
@@ -1,4 +1,5 @@
 """Covers the ward name and per-profile title/subtitle settings (commit 496892f)."""
+# pylint: disable=missing-function-docstring
 from pages.settings_modal import SettingsModal
 
 

--- a/e2e/tests/test_side_drawer_navigation.py
+++ b/e2e/tests/test_side_drawer_navigation.py
@@ -1,4 +1,5 @@
 """Covers the collapsible side navigation drawer (commit 85ebcd9)."""
+# pylint: disable=missing-function-docstring,unused-argument
 
 
 def test_drawer_starts_closed(calendar_page, side_drawer):

--- a/e2e/tests/test_side_drawer_navigation.py
+++ b/e2e/tests/test_side_drawer_navigation.py
@@ -1,0 +1,36 @@
+"""Covers the collapsible side navigation drawer (commit 85ebcd9)."""
+
+
+def test_drawer_starts_closed(calendar_page, side_drawer):
+    assert not side_drawer.is_open()
+
+
+def test_menu_button_opens_and_backdrop_closes_drawer(calendar_page, side_drawer):
+    calendar_page.open_drawer()
+    assert side_drawer.is_open()
+
+    calendar_page.close_drawer_via_backdrop()
+    assert not side_drawer.is_open()
+
+
+def test_nav_items_are_calendar_and_baptismal_plan(side_drawer, calendar_page):
+    calendar_page.open_drawer()
+    labels = [label.strip() for label in side_drawer.nav_item_labels()]
+    assert labels == ["Calendário", "Planejamento Batismal"]
+
+
+def test_navigating_switches_view_and_closes_drawer(calendar_page, side_drawer):
+    calendar_page.navigate_to("/baptismal-plan")
+
+    assert calendar_page.page.locator("#baptismalPlanView").is_visible()
+    assert calendar_page.page.locator("#calendarView").is_hidden()
+    assert not side_drawer.is_open()
+    assert side_drawer.active_route() == "/baptismal-plan"
+
+
+def test_dev_mode_sign_out_closes_drawer_without_error(calendar_page, side_drawer):
+    calendar_page.open_drawer()
+    side_drawer.sign_out()
+
+    assert not side_drawer.is_open()
+    assert calendar_page.page.locator("#calendarView").is_visible()

--- a/e2e/tests/test_ui_smoke.py
+++ b/e2e/tests/test_ui_smoke.py
@@ -1,6 +1,7 @@
 """Small standalone UI facts: dark theme (commit 552e70d, static CSS only — no toggle
 exists in the current UI) and favicon/branding (commit 857dded).
 """
+# pylint: disable=missing-function-docstring
 
 
 def test_dark_theme_background_and_form_controls(calendar_page):

--- a/e2e/tests/test_ui_smoke.py
+++ b/e2e/tests/test_ui_smoke.py
@@ -1,0 +1,28 @@
+"""Small standalone UI facts: dark theme (commit 552e70d, static CSS only — no toggle
+exists in the current UI) and favicon/branding (commit 857dded).
+"""
+
+
+def test_dark_theme_background_and_form_controls(calendar_page):
+    bg_var = calendar_page.page.evaluate(
+        "getComputedStyle(document.documentElement).getPropertyValue('--bg').trim()"
+    )
+    assert bg_var == "#0c121b"
+
+    month_picker_color_scheme = calendar_page.page.evaluate(
+        "getComputedStyle(document.getElementById('monthPicker')).colorScheme"
+    )
+    assert month_picker_color_scheme == "dark"
+
+
+def test_page_title(calendar_page):
+    assert calendar_page.page.title() == "Assistente da Obra Missionária"
+
+
+def test_favicon_link_and_asset(calendar_page, live_server, context):
+    href = calendar_page.page.locator('link[rel="icon"]').get_attribute("href")
+    assert href == "/favicon.svg"
+
+    response = context.request.get(f"{live_server.base_url}{href}")
+    assert response.ok
+    assert "svg" in response.headers.get("content-type", "")

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -869,14 +869,14 @@ tbody td.week-cell {
 .bp-editor-area {
   flex: 1;
   min-width: 0;
-  padding: 24px 380px;
+  padding: 84px 380px 24px;
   overflow-y: auto;
   height: 100%;
 }
 
 @media (max-width: 1400px) {
   .bp-editor-area {
-    padding: 24px 40px;
+    padding: 84px 40px 24px;
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds a Python `pytest` + `pytest-playwright` e2e framework under `e2e/` (Page Object Model), covering every user-facing feature and bug-fix regression reachable from `main`, mapped to the commit(s) that introduced them.
- Adds `e2e/COVERAGE.md`, a living tracker mapping each feature/bugfix to its commit(s) and test file(s), so coverage stays visible as new features land. Two items from the original commit history (the 3-couple "Duplas Missionárias" slider and the deprecation-notice banner) turned out to live only on unmerged branches — no code for them exists on `main`, so they're marked `N/A (unmerged)` rather than tested against a phantom UI.
- Adds `.github/workflows/e2e.yml`, running the full suite on every PR (and on push to `main`), using `uv` for dependency install (per this repo's package-management preference) and Playwright's own Chromium install — no Docker/Node required, since the fixture launches `src/app.py --dev` directly as a subprocess.
- Isolates test data from any real local `calendar_data.json` by running the server with its working directory pointed at a throwaway temp dir per test session, and resets both JSON store files before every test.

## Incidental fixes found while writing the tests

- **Data isolation bug**: `BaptismalPlanJsonStore` writes to a sibling `calendar_data_baptismal_plans.json` file, separate from the calendar store's file. The e2e reset fixture only tracked the latter, which would have leaked baptismal-plan test data across every test run.
- **UI bug**: the fixed top nav bar (58px tall) visually overlapped and blocked clicks on the baptismal-plan editor's toolbar — including the "Exportar PDF" button — because `.bp-editor-area` was missing the top padding that `.bp-history` (the panel next to it) already had. One-line CSS fix in `src/views/styles.css`.

## Test plan

- [x] `python -m unittest discover -s tests -v` — 87 tests pass, unchanged.
- [x] `pylint $(git ls-files '*.py')` — 10.00/10.
- [x] `pytest e2e/tests -v` — 43/43 pass locally against `src/app.py --dev`.
- [x] Screenshot-verified the CSS fix: the "Exportar PDF" button is no longer covered by the nav bar.
- [ ] Confirm the new `E2E Tests` GitHub Actions workflow passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)